### PR TITLE
Create Offer and Related Models

### DIFF
--- a/app/Enums/ActivityTypeEnum.php
+++ b/app/Enums/ActivityTypeEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum ActivityTypeEnum: string
+{
+    case CONFERENCE = "conference";
+    case FORMATION = "formation";
+
+    public static function values(): array
+    {
+        return array_map(
+            fn(self $enum) => $enum->value,
+            self::cases()
+        );
+    }
+}

--- a/app/Enums/CandidacyStatusEnum.php
+++ b/app/Enums/CandidacyStatusEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum CandidacyStatusEnum: string
+{
+    case PENDING = "pending";
+    case ACCEPTED = "accepted";
+    case REFUSED = "refused";
+
+    public static function values(): array
+    {
+        return array_map(
+            fn(self $enum) => $enum->value,
+            self::cases()
+        );
+    }
+}

--- a/app/Enums/ParticipatedStatusEnum.php
+++ b/app/Enums/ParticipatedStatusEnum.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Enums;
+
+enum ParticipatedStatusEnum: string
+{
+    case PENDING = "pending";
+    case ACCEPTED = "accepted";
+    case REFUSED = "refused";
+
+    public static function values(): array
+    {
+        return array_map(
+            fn(self $enum) => $enum->value,
+            self::cases()
+        );
+    }
+}

--- a/app/Enums/ProfessionEnum.php
+++ b/app/Enums/ProfessionEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Enums;
+
+enum ProfessionEnum: string
+{
+    case STUDENT = "student";
+
+    case EMPLOYEE = "employee";
+
+    case RETIRED = "retired";
+
+    public static function values(): array
+    {
+        return array_map(
+            fn(self $enum) => $enum->value,
+            self::cases()
+        );
+    }
+}

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ActivityTypeEnum;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Activity extends Model
+{
+    /** @use HasFactory<\Database\Factories\ActivityFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'image',
+        'title',
+        'description',
+        'content',
+        'start_at',
+        'end_at',
+        'type',
+    ];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'type' =>  ActivityTypeEnum::class,
+    ];
+}

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -27,4 +27,12 @@ class Activity extends Model
         'end_at' => 'datetime',
         'type' =>  ActivityTypeEnum::class,
     ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Participant, Activity>
+     */
+    public function participants()
+    {
+        return $this->hasMany(Participant::class);
+    }
 }

--- a/app/Models/Candidacy.php
+++ b/app/Models/Candidacy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\CandidacyStatusEnum;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Candidacy extends Model
+{
+    /** @use HasFactory<\Database\Factories\CandidacyFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'offer_id',
+        'candidate_id',
+        'status',
+        'cv_path',
+    ];
+
+    protected $casts = [
+        'status' => CandidacyStatusEnum::class,
+    ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Candidate, Candidacy>
+     */
+    public function candidate()
+    {
+        return $this->belongsTo(Candidate::class);
+    }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Offer, Candidacy>
+     */
+    public function offer()
+    {
+        return $this->belongsTo(Offer::class);
+    }
+}

--- a/app/Models/Candidate.php
+++ b/app/Models/Candidate.php
@@ -32,4 +32,12 @@ class Candidate extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Candidacy, Candidate>
+     */
+    public function candidacies()
+    {
+        return $this->hasMany(Candidacy::class);
+    }
 }

--- a/app/Models/JobPosition.php
+++ b/app/Models/JobPosition.php
@@ -15,4 +15,13 @@ class JobPosition extends Model
         'name',
         'description',
     ];
+
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<Offer, JobPosition, \Illuminate\Database\Eloquent\Relations\Pivot>
+     */
+    public function offers()
+    {
+        return $this->belongsToMany(Offer::class);
+    }
 }

--- a/app/Models/JobPosition.php
+++ b/app/Models/JobPosition.php
@@ -24,4 +24,12 @@ class JobPosition extends Model
     {
         return $this->belongsToMany(Offer::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Skill, JobPosition>
+     */
+    public function skills()
+    {
+        return $this->hasMany(Skill::class);
+    }
 }

--- a/app/Models/JobPosition.php
+++ b/app/Models/JobPosition.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JobPosition extends Model
+{
+    /** @use HasFactory<\Database\Factories\JobPositionFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+}

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -33,4 +33,13 @@ class Offer extends Model
     {
         return $this->belongsTo(Recruiter::class);
     }
+    
+  
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<JobPosition, Offer, \Illuminate\Database\Eloquent\Relations\Pivot>
+     */
+    public function jobPosition()
+    {
+        return $this->belongsToMany(JobPosition::class);
+    }
 }

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Offer extends Model
+{
+    /** @use HasFactory<\Database\Factories\OfferFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'image',
+        'name',
+        'bio',
+        'description',
+        'start_at',
+        'end_at',
+        'gender',
+        'user_id'
+    ];
+
+    protected $casts = [
+        'start_at' => 'date',
+        'end_at' => 'date',
+    ];
+}

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -18,12 +18,19 @@ class Offer extends Model
         'description',
         'start_at',
         'end_at',
-        'gender',
-        'user_id'
+        'recruiter_id'
     ];
 
     protected $casts = [
         'start_at' => 'date',
         'end_at' => 'date',
     ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Recruiter, Offer>
+     */
+    public function recruiter()
+    {
+        return $this->belongsTo(Recruiter::class);
+    }
 }

--- a/app/Models/Offer.php
+++ b/app/Models/Offer.php
@@ -42,4 +42,12 @@ class Offer extends Model
     {
         return $this->belongsToMany(JobPosition::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Candidacy, Offer>
+     */
+    public function candidacies()
+    {
+        return $this->hasMany(Candidacy::class);
+    }
 }

--- a/app/Models/Participant.php
+++ b/app/Models/Participant.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\GenderEnum;
 use App\Enums\ProfessionEnum;
+use App\Enums\ParticipatedStatusEnum;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,10 +20,21 @@ class Participant extends Model
         'email',
         'gender',
         'profession',
+        'activity_id',
+        'status'
     ];
 
     protected $casts = [
         'profession' => ProfessionEnum::class,
         'gender' => GenderEnum::class,
+        'status' => ParticipatedStatusEnum::class
     ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<Activity, Participant>
+     */
+    public function activity()
+    {
+        return $this->belongsTo(Activity::class);
+    }
 }

--- a/app/Models/Participant.php
+++ b/app/Models/Participant.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\GenderEnum;
+use App\Enums\ProfessionEnum;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Participant extends Model
+{
+    /** @use HasFactory<\Database\Factories\ParticipantFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'name',
+        'firstname',
+        'email',
+        'gender',
+        'profession',
+    ];
+
+    protected $casts = [
+        'profession' => ProfessionEnum::class,
+        'gender' => GenderEnum::class,
+    ];
+}

--- a/app/Models/Recruiter.php
+++ b/app/Models/Recruiter.php
@@ -31,4 +31,12 @@ class Recruiter extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<Offer, Recruiter>
+     */
+    public function offers()
+    {
+        return $this->hasMany(Offer::class);
+    }
 }

--- a/app/Models/Skill.php
+++ b/app/Models/Skill.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Skill extends Model
+{
+    /** @use HasFactory<\Database\Factories\SkillFactory> */
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+}

--- a/app/Models/Skill.php
+++ b/app/Models/Skill.php
@@ -14,5 +14,14 @@ class Skill extends Model
     protected $fillable = [
         'name',
         'description',
+        'job_position_id'
     ];
+
+    /**
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<JobPosition, Skill>
+     */
+    public function jobPosition()
+    {
+        return $this->belongsTo(JobPosition::class);
+    }
 }

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ActivityTypeEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Activity>
+ */
+class ActivityFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'image' => fake()->imageUrl(),
+            'title' => fake()->unique()->sentence(1),
+            'content' => fake()->paragraph(5),
+            'description' => fake()->text(),
+            'start_at' => fake()->date(),
+            'end_at' => fake()->date(),
+            'type' => fake()->randomElement(ActivityTypeEnum::cases())->value,
+        ];
+    }
+}

--- a/database/factories/CandidacyFactory.php
+++ b/database/factories/CandidacyFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CandidacyStatusEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Candidacy>
+ */
+class CandidacyFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'status' => fake()->randomElement(CandidacyStatusEnum::cases())->value,
+            'cv_path' => fake()->url(),
+        ];
+    }
+}

--- a/database/factories/JobPositionFactory.php
+++ b/database/factories/JobPositionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\JobPosition>
+ */
+class JobPositionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'description' => fake()->text(),
+        ];
+    }
+}

--- a/database/factories/OfferFactory.php
+++ b/database/factories/OfferFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Offer>
+ */
+class OfferFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'image' => fake()->imageUrl(),
+            'name' => fake()->sentence(1),
+            'bio' => fake()->sentence(),
+            'description' => fake()->text(),
+            'start_at' => fake()->date(),
+            'end_at' => fake()->date(),
+        ];
+    }
+}

--- a/database/factories/ParticipantFactory.php
+++ b/database/factories/ParticipantFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Enums\GenderEnum;
+use App\Enums\ParticipatedStatusEnum;
 use App\Enums\ProfessionEnum;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -24,6 +25,7 @@ class ParticipantFactory extends Factory
             'email' => fake()->email,
             'gender' => fake()->randomElement(GenderEnum::cases())->value,
             'profession' => fake()->randomElement(ProfessionEnum::cases())->value,
+            'status' => fake()->randomElement(ParticipatedStatusEnum::cases())->value,
         ];
     }
 }

--- a/database/factories/ParticipantFactory.php
+++ b/database/factories/ParticipantFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\GenderEnum;
+use App\Enums\ProfessionEnum;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Participant>
+ */
+class ParticipantFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name,
+            'firstname' => fake()->firstname,
+            'email' => fake()->email,
+            'gender' => fake()->randomElement(GenderEnum::cases())->value,
+            'profession' => fake()->randomElement(ProfessionEnum::cases())->value,
+        ];
+    }
+}

--- a/database/factories/SkillFactory.php
+++ b/database/factories/SkillFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Skill>
+ */
+class SkillFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'description' => fake()->text(),
+        ];
+    }
+}

--- a/database/migrations/2025_09_10_214246_create_offers_table.php
+++ b/database/migrations/2025_09_10_214246_create_offers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('offers', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('image')->nullable();
+            $table->string('name');
+            $table->text('bio');
+            $table->date('start_at');
+            $table->date('end_at');
+            $table->longText('description');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('offers');
+    }
+};

--- a/database/migrations/2025_09_10_221757_foreign_offer_recruiter_column_table_offers.php
+++ b/database/migrations/2025_09_10_221757_foreign_offer_recruiter_column_table_offers.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('offers', function (Blueprint $table) {
+            $table->uuid('recruiter_id');
+            $table->foreign('recruiter_id')
+                ->references('id')
+                ->on('recruiters')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('offers', function (Blueprint $table) {
+            $table->dropForeign('recruiter_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_10_223125_create_job_positions_table.php
+++ b/database/migrations/2025_09_10_223125_create_job_positions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_positions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_positions');
+    }
+};

--- a/database/migrations/2025_09_10_224944_many_to_many_job_position_offer_table.php
+++ b/database/migrations/2025_09_10_224944_many_to_many_job_position_offer_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_position_offer', function (Blueprint $table) {
+            $table->uuid('offer_id');
+            $table->uuid('job_position_id');
+            $table->foreign('offer_id')
+                ->references('id')
+                ->on('offers')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+             $table->foreign('job_position_id')
+                ->references('id')
+                ->on('job_positions')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->primary(['job_position_id', 'offer_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_position_offer');
+    }
+};

--- a/database/migrations/2025_09_11_064424_create_skills_table.php
+++ b/database/migrations/2025_09_11_064424_create_skills_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('skills', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skills');
+    }
+};

--- a/database/migrations/2025_09_11_065115_foreign_job_position_skill_column_table_skills.php
+++ b/database/migrations/2025_09_11_065115_foreign_job_position_skill_column_table_skills.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('skills', function (Blueprint $table) {
+            $table->uuid('job_position_id');
+            $table->foreign('job_position_id')
+                ->references('id')
+                ->on('job_positions')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('skills', function (Blueprint $table) {
+            $table->dropForeign('job_position_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_11_083143_create_candidacies_table.php
+++ b/database/migrations/2025_09_11_083143_create_candidacies_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Enums\CandidacyStatusEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('candidacies', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('offer_id');
+            $table->uuid('candidate_id');
+            $table->foreign('offer_id')
+                ->references('id')
+                ->on('offers')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->foreign('candidate_id')
+                ->references('id')
+                ->on('candidates')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->enum('status', CandidacyStatusEnum::values());
+            $table->string('cv_path');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('candidacies');
+    }
+};

--- a/database/migrations/2025_09_13_085921_create_activities_table.php
+++ b/database/migrations/2025_09_13_085921_create_activities_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Enums\ActivityTypeEnum;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activities', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('image')->nullable(); 
+            $table->string('title')->unique();
+            $table->date('start_at');
+            $table->date('end_at');
+            $table->text('description');
+            $table->longText('content');
+            $table->enum('type', ActivityTypeEnum::values());
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activities');
+    }
+};

--- a/database/migrations/2025_09_13_094245_create_participants_table.php
+++ b/database/migrations/2025_09_13_094245_create_participants_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Enums\GenderEnum;
+use App\Enums\ProfessionEnum;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('participants', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('firstname');
+            $table->string('email');
+            $table->enum('profession', ProfessionEnum::values());
+            $table->enum('gender', GenderEnum::values());
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('participants');
+    }
+};

--- a/database/migrations/2025_09_13_100551_add_columns_table_participants.php
+++ b/database/migrations/2025_09_13_100551_add_columns_table_participants.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Enums\ParticipatedStatusEnum;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('participants', function (Blueprint $table) {
+            $table->uuid('activity_id');
+            $table->foreign('activity_id')
+                ->references('id')
+                ->on('activities')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+            $table->enum('status', ParticipatedStatusEnum::values());
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('participants', function (Blueprint $table) {
+            $table->dropForeign('activity_id');
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -58,6 +58,14 @@ class DatabaseSeeder extends Seeder
             $offer->jobPosition()->sync($jobsIds);
         }
 
-        Skill::factory(30)->create();
+
+        foreach (JobPosition::all() as $job) {
+            $randomMaxJSkills = random_int(2, 5);
+
+            Skill::factory($randomMaxJSkills)->create([
+                'job_position_id' => $job->id
+            ]);
+
+        }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -47,5 +47,14 @@ class DatabaseSeeder extends Seeder
         }
 
         JobPosition::factory(10)->create();
+
+        foreach (Offer::all() as $offer) {
+            $randomMaxJobPositions = random_int(2, 3);
+            $jobsIds = [];
+            for ($i=0; $i < $randomMaxJobPositions; $i++) { 
+                $jobsIds[] = JobPosition::all()->random()->id;
+            }
+            $offer->jobPosition()->sync($jobsIds);
+        }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -78,7 +78,12 @@ class DatabaseSeeder extends Seeder
                 ]);
             }
         }
-        Activity::factory(20)->create();
-        Participant::factory(30)->create();
+        $activities = Activity::factory(20)->create();
+
+        foreach ($activities as $activity) {
+            Participant::factory(30)->create([
+                'activity_id' => $activity->id,
+            ]);
+        }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,15 +2,17 @@
 
 namespace Database\Seeders;
 
+use App\Models\User;
+use App\Models\Offer;
+use App\Models\Skill;
 use App\Models\Activity;
 use App\Models\Candidacy;
 use App\Models\Candidate;
-use App\Models\JobPosition;
-use App\Models\Offer;
-use App\Models\Skill;
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Recruiter;
+use App\Models\JobPosition;
+// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Participant;
+use App\Models\ActivityForm;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -76,7 +78,7 @@ class DatabaseSeeder extends Seeder
                 ]);
             }
         }
-
         Activity::factory(20)->create();
+        Participant::factory(30)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Candidacy;
 use App\Models\Candidate;
 use App\Models\JobPosition;
 use App\Models\Offer;
@@ -52,12 +53,11 @@ class DatabaseSeeder extends Seeder
         foreach (Offer::all() as $offer) {
             $randomMaxJobPositions = random_int(2, 3);
             $jobsIds = [];
-            for ($i=0; $i < $randomMaxJobPositions; $i++) { 
+            for ($i=0; $i < $randomMaxJobPositions; $i++) {
                 $jobsIds[] = JobPosition::all()->random()->id;
             }
             $offer->jobPosition()->sync($jobsIds);
         }
-
 
         foreach (JobPosition::all() as $job) {
             $randomMaxJSkills = random_int(2, 5);
@@ -65,7 +65,15 @@ class DatabaseSeeder extends Seeder
             Skill::factory($randomMaxJSkills)->create([
                 'job_position_id' => $job->id
             ]);
+        }
 
+        foreach (Offer::all() as $offer) {
+            foreach (Candidate::all() as $candidate) {
+                Candidacy::factory()->create([
+                    'offer_id' => $offer->id,
+                    'candidate_id' => $candidate->id
+                ]);
+            }
         }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Candidate;
 use App\Models\JobPosition;
 use App\Models\Offer;
+use App\Models\Skill;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Recruiter;
@@ -56,5 +57,7 @@ class DatabaseSeeder extends Seeder
             }
             $offer->jobPosition()->sync($jobsIds);
         }
+
+        Skill::factory(30)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Candidate;
+use App\Models\Offer;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use App\Models\Recruiter;
@@ -37,5 +38,8 @@ class DatabaseSeeder extends Seeder
                 'user_id' => $user->id
             ]);
         }
+
+
+        Offer::factory(30)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Activity;
 use App\Models\Candidacy;
 use App\Models\Candidate;
 use App\Models\JobPosition;
@@ -75,5 +76,7 @@ class DatabaseSeeder extends Seeder
                 ]);
             }
         }
+
+        Activity::factory(20)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Candidate;
+use App\Models\JobPosition;
 use App\Models\Offer;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
@@ -44,5 +45,7 @@ class DatabaseSeeder extends Seeder
                 'recruiter_id' => $recruiter->id
             ]);
         }
+
+        JobPosition::factory(10)->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -39,7 +39,10 @@ class DatabaseSeeder extends Seeder
             ]);
         }
 
-
-        Offer::factory(30)->create();
+        foreach (Recruiter::all() as $recruiter) {
+            Offer::factory(2)->create([
+                'recruiter_id' => $recruiter->id
+            ]);
+        }
     }
 }


### PR DESCRIPTION

This merge introduces the `Offer` model along with related models and database structure for job management. Key changes include:

* **Offer Model**

  * Added `Offer` model with foreign key to `Recruiter` (`offer_recruiter`)
  * Seeded initial offer data

* **Job Position**

  * Created `JobPosition` model
  * Added pivot table `job_position_offer` to link job positions and offers

* **Skills**

  * Created `Skill` model
  * Added pivot table `skill_job_position` with foreign keys
  * Seeded skill data

* **Candidacy**

  * Created `Candidacy` model to manage applications

* **Activity & Participants**

  * Created `Activity` and `Participant` models
  * Added pivot table `activity_participant` with foreign keys
  * Added `status` column to `activity_participant`

